### PR TITLE
Quote path used in gvim command

### DIFF
--- a/lib/everything/cli.rb
+++ b/lib/everything/cli.rb
@@ -57,7 +57,7 @@ YAML
         exit
       end
 
-      fork { `gvim -O #{path}/index.{yaml,md}` }
+      fork { `gvim -O "#{path}"/index.{yaml,md}` }
     end
     map 'o' => 'open'
 


### PR DESCRIPTION
This helps support paths that contain special characters like spaces, parens, etc.

Otherwise, I got an error like this while trying to run this command:
```
sh: -c: line 0: syntax error near unexpected token `('
sh: -c: line 0: `gvim -O /Users/kyletolle/Dropbox (Personal)/everything/novels/bones-of-a-broken-world/draft-1/ch2/index.{yaml,md}'
```